### PR TITLE
redoing test assignment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,51 @@
+name: Django CI
+
+on:
+  push:
+    branches:
+      - main
+      - testing
+  pull_request:
+    branches:
+      - main
+      - testing
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install playwright
+          playwright install
+
+      - name: Run Migrations
+        run: |
+          cd ledgerpay
+          python manage.py migrate
+
+      - name: Run Unit & Integration Tests
+        run: |
+          cd ledgerpay
+          python manage.py runserver  &
+          sleep 7 
+          pytest --cov=payments --cov-report=xml
+
+      - name: Upload Coverage Report
+        uses: codecov/codecov-action@v4
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-report
+

--- a/ledgerpay/payments/pytest.ini
+++ b/ledgerpay/payments/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = ledgerpay.settings
+python_files = tests.py test_*.py *_tests.py

--- a/ledgerpay/payments/tests/e2e/test_playwright_login.py
+++ b/ledgerpay/payments/tests/e2e/test_playwright_login.py
@@ -1,0 +1,26 @@
+"""These are our end-to-end tests for signing in """
+
+from playwright.sync_api import sync_playwright
+
+def test_login_django_admin():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+
+        # Navigate to the Django admin login page
+        page.goto("http://127.0.0.1:8000/admin/")
+
+        # Fill in login credentials
+        page.fill("input[name='username']", "user")
+        page.fill("input[name='password']", "password")
+
+        # Submit login form
+        page.press("input[name='password']", "Enter")
+
+        # Wait for the admin page to load
+        page.wait_for_selector("body")
+
+        # Assert that login was successful by checking for a known element
+        assert "Site administration" in page.inner_text("body"), "❌ Login failed!"
+
+        browser.close()

--- a/ledgerpay/payments/tests/test_integrations.py
+++ b/ledgerpay/payments/tests/test_integrations.py
@@ -1,0 +1,51 @@
+"""These are our integration tests for our wallets and transactions """
+
+from django.test import TestCase
+from django.contrib.auth.models import User
+from ..models import Wallet, Transaction
+from decimal import Decimal
+
+
+class WalletTransactionIntegrationTest(TestCase):
+
+    def setUp(self):
+        """Creating a user and wallet before each test"""
+        self.user = User.objects.create_user(username="testuser", email="test@example.com", password="password123")
+        self.wallet = Wallet.objects.create(associated_user=self.user, balance=Decimal("100.00"),
+                                            payment_token="testtoken")
+
+    def test_successful_transaction_updates_wallet_balance(self):
+        """Test that a successful transaction deducts the amount from the wallet balance"""
+        initial_balance = self.wallet.balance
+        transaction_amount = Decimal("30.00")
+
+        # Create a transaction
+        transaction = Transaction.objects.create(
+            associated_user=self.user,
+            amount=transaction_amount,
+            transaction_address="0x123abc"
+        )
+
+        # Simulate deducting from wallet
+        self.wallet.balance -= transaction.amount
+        self.wallet.save()
+
+        self.wallet.refresh_from_db()  # Reload wallet from database
+        self.assertEqual(self.wallet.balance, initial_balance - transaction_amount)
+
+    def test_transaction_fails_if_insufficient_balance(self):
+        """Test that a transaction fails if the wallet has insufficient funds"""
+        transaction_amount = Decimal("150.00")  # More than wallet balance
+
+        with self.assertRaises(ValueError):  # Expect an error
+            transaction = Transaction.objects.create(
+                associated_user=self.user,
+                amount=transaction_amount,
+                transaction_address="0x456def"
+            )
+            # Simulate balance deduction (add validation in models.py)
+            if self.wallet.balance < transaction.amount:
+                raise ValueError("Insufficient funds")
+
+            self.wallet.balance -= transaction.amount
+            self.wallet.save()

--- a/ledgerpay/payments/tests/test_models.py
+++ b/ledgerpay/payments/tests/test_models.py
@@ -1,0 +1,57 @@
+"""These are our unit tests for our model classes"""
+from django.test import TestCase
+from django.contrib.auth.models import User
+from ..models import  Wallet, Transaction
+from decimal import Decimal
+
+class WalletModelTest(TestCase):
+
+    def setUp(self):
+        """Creating a test user before each test"""
+        self.user = User.objects.create_user(username="testuser", email="test@example.com", password="password123")
+
+    def test_create_wallet_successfully(self):
+        """Test creating a wallet with valid data"""
+        wallet = Wallet.objects.create(associated_user=self.user, balance=Decimal("100.50"), payment_token="abc123xyz")
+        self.assertEqual(wallet.associated_user, self.user)
+        self.assertEqual(wallet.balance, Decimal("100.50"))
+        self.assertEqual(wallet.payment_token, "abc123xyz")
+
+    def test_wallet_str_method(self):
+        """Test the string representation of the Wallet model"""
+        wallet = Wallet.objects.create(associated_user=self.user, balance=Decimal("50.00"), payment_token="xyz987abc")
+        self.assertEqual(str(wallet), "test@example.com's Wallet")
+
+    def test_create_wallet_with_negative_balance(self):
+        """Test creating a wallet with a negative balance should raise an error"""
+        with self.assertRaises(ValueError):
+            Wallet.objects.create(associated_user=self.user, balance=Decimal("-10.00"), payment_token="invalid")
+
+
+class TransactionModelTest(TestCase):
+
+    def setUp(self):
+        """Createing a test user before each test"""
+        self.user = User.objects.create_user(username="testuser", email="test@example.com", password="password123")
+
+    def test_create_transaction_successfully(self):
+        """Test creating a transaction with valid data"""
+        transaction = Transaction.objects.create(
+            associated_user=self.user, amount=Decimal("25.75"), transaction_address="0x123abc"
+        )
+        self.assertEqual(transaction.associated_user, self.user)
+        self.assertEqual(transaction.amount, Decimal("25.75"))
+        self.assertEqual(transaction.transaction_address, "0x123abc")
+
+    def test_transaction_str_method(self):
+        """Test the string representation of the Transaction model"""
+        transaction = Transaction.objects.create(
+            associated_user=self.user, amount=Decimal("99.99"), transaction_address="0x456def"
+        )
+        self.assertEqual(str(transaction), "transaction of $99.99 to test@example.com")
+
+    def test_create_transaction_with_negative_amount(self):
+        """Test creating a transaction with a negative amount should raise an error"""
+        with self.assertRaises(ValueError):
+            Transaction.objects.create(associated_user=self.user, amount=Decimal("-5.00"), transaction_address="invalid")
+

--- a/ledgerpay/payments/tests/test_utils.py
+++ b/ledgerpay/payments/tests/test_utils.py
@@ -1,0 +1,25 @@
+"""These are our unit tests for the utility 'can_transfer function'"""
+
+import unittest
+from decimal import Decimal
+from ..utils import can_transfer
+
+class CanTransferTestCase(unittest.TestCase):
+
+    def test_sufficient_balance(self):
+        self.assertTrue(can_transfer(Decimal("100.00"), Decimal("50.00")))
+
+    def test_exact_balance(self):
+        self.assertTrue(can_transfer(Decimal("25.00"), Decimal("25.00")))
+
+    def test_insufficient_balance(self):
+        self.assertFalse(can_transfer(Decimal("10.00"), Decimal("20.00")))
+
+    def test_zero_transfer(self):
+        self.assertFalse(can_transfer(Decimal("50.00"), Decimal("0.00")))
+
+    def test_negative_transfer(self):
+        self.assertFalse(can_transfer(Decimal("50.00"), Decimal("-10.00")))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ledgerpay/payments/utils.py
+++ b/ledgerpay/payments/utils.py
@@ -1,0 +1,7 @@
+from decimal import Decimal
+
+def can_transfer(balance: Decimal, amount: Decimal) -> bool:
+    """
+    Returns True if balance is enough and amount is positive.
+    """
+    return balance >= amount and amount > 0

--- a/ledgerpay/payments/views.py
+++ b/ledgerpay/payments/views.py
@@ -1,9 +1,58 @@
 from django.shortcuts import render
 from django.contrib.auth.decorators import login_required
 from .models import Wallet, Transaction
+from django.views.decorators.http import require_POST
+from decimal import Decimal
+from django.http import JsonResponse
+from .utils import can_transfer
+from django.shortcuts import get_object_or_404
+from django.contrib.auth.models import User
 
 # Create your views here.
 @login_required(login_url="login")
 def dashboard(request):
     all_user_transactions = Transaction.objects.filter(associated_user=request.user)
     return render(request, 'payments/dashboard.html', context={"transactions": all_user_transactions})
+
+
+
+
+@require_POST
+@login_required
+def transfer_funds(request):
+    sender = request.user
+    recipient_email = request.POST.get("recipient_email")
+    amount_str = request.POST.get("amount")
+    tx_address = request.POST.get("transaction_address")
+
+    # Validate and parse amount
+    try:
+        amount = Decimal(amount_str)
+    except:
+        return JsonResponse({"error": "Invalid amount format"}, status=400)
+
+    # Get wallets and users
+    sender_wallet = get_object_or_404(Wallet, associated_user=sender)
+    recipient_user = get_object_or_404(User, email=recipient_email)
+    recipient_wallet = get_object_or_404(Wallet, associated_user=recipient_user)
+
+    # Check transfer validity
+    if not can_transfer(sender_wallet.balance, amount):
+        return JsonResponse({"error": "Insufficient or invalid transfer amount"}, status=400)
+
+    # Perform transaction
+    sender_wallet.balance -= amount
+    recipient_wallet.balance += amount
+    sender_wallet.save()
+    recipient_wallet.save()
+
+    Transaction.objects.create(
+        amount=amount,
+        transaction_address=tx_address or "Internal Transfer",
+        associated_user=recipient_user
+    )
+
+    return JsonResponse({
+        "message": f"Transferred ${amount} to {recipient_email} successfully.",
+        "new_balance": str(sender_wallet.balance)
+    })


### PR DESCRIPTION
This pull request enhances the test coverage of the payments module, increasing it from 36% to 88%. Previously, critical files like views.py and urls.py had 0% coverage, and some model logic remained untested. With the new unit and integration tests, tests.py and models.py now have 100% coverage, ensuring core functionalities are well-tested.
I have implemented the necessary testing framework for our project by installing pytest and pytest-django. Within the payments app, I created a tests/ directory that contains three test files: test_models.py, which performs integration tests on our model classes, test_integrations.py, which tests the interaction between the Wallet and Transaction models and test_utils which performs unit tests on our utility functions. Additionally, I added an e2e/ directory that contains end-to-end tests written with Playwright. These tests simulate a user logging into the site using admin credentials.
To run the tests, first install all dependencies from requirements.txt. Since Playwright requires additional libraries for browser automation, these can be installed by running playwright install. For the end-to-end tests, the Django server must be running in one terminal while the test is executed in another. Once all dependencies are installed and the server is running, navigate to the root directory of the Django project (where manage.py is located) and run pytest to execute the tests.

<img width="1324" alt="pre_cov_report" src="https://github.com/user-attachments/assets/a06b1868-9d70-444f-ac4e-280bbe8c04cb" />
<img width="1264" alt="post_cov_report" src="https://github.com/user-attachments/assets/f14b94ec-bb18-49be-a12b-c0112a1da525" />
